### PR TITLE
Bumpversion implementation in meta.yml 

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,20 +1,20 @@
 [bumpversion]
-current_version = 2.13.0.dev14
+current_version = 2.13.0.dev13
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	dev
 	gamma
 
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search = version = "{current_version}"
-replace = version = "{new_version}"
+search = git_rev = "{current_version}"
+replace = git_rev = "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.1.dev2
+current_version = 2.13.0.dev13
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,5 +16,5 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search = git_rev = "{current_version}"
-replace = git_rev = "{new_version}"
+search = git_rev = "v{current_version}"
+replace = git_rev = "v{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,5 +16,5 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search = {%- set version = "{current_version}" %}.*{%- set git_rev = "v{current_version}" %}
-replace = {%- set version = "{new_version}" %} {%- set git_rev = "v{new_version}" %}
+search = version: "{current_version}"
+replace = version: "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,9 +16,5 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search =
-    {% set version = "{current_version}" %}
-    {% set git_rev = "v{current_version}" %}
-replace =
-    {% set version = "{new_version}" %}
-    {% set git_rev = "v{new_version}" %}
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.0.dev18
+current_version = 2.13.0.dev19
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,15 +1,15 @@
 [bumpversion]
-current_version = 2.13.0.dev15
+current_version = 2.13.0.dev16
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values =
+values = 
 	dev
 	gamma
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,15 +1,15 @@
 [bumpversion]
-current_version = 2.13.0.dev16
+current_version = 2.13.0.dev15
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	dev
 	gamma
 
@@ -17,4 +17,4 @@ values =
 
 [bumpversion:file:recipe/meta.yaml]
 search = version = "{current_version}"
-replace = version = "{current_version}"
+replace = version = "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -18,7 +18,3 @@ values =
 [bumpversion:file:recipe/meta.yaml]
 search = {{%- set version = "{current_version}" %}}
 replace = {%- set version = "{new_version}" %}
-
-
-search = {{%- set git_rev = "v{current_version}" %}}
-replace = {%- set git_rev = "v{new_version}" %}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.0.dev20
+current_version = 2.13.0.dev21
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.0.dev17
+current_version = 2.13.0.dev18
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,5 +16,9 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search = version = "{current_version}"
-replace = version = "{new_version}"
+search =
+    version = "{current_version}"
+    git_rev = "v{current_version}"
+replace =
+    version = "{new_version}"
+    git_rev = "v{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,17 +3,22 @@ current_version = 2.13.0.dev15
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	dev
 	gamma
 
 [bumpversion:part:dev]
+
+[bumpversion:file:recipe/meta.yaml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
 
 [bumpversion:file:recipe/meta.yaml]
 search = git_rev = "v{current_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.1.dev1
+current_version = 2.13.1.dev2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,5 +16,5 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search = version: {current_version}
-replace = version: {new_version}
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,5 +16,5 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search = version: "{current_version}"
-replace = version: "{new_version}"
+search = version: {current_version}
+replace = version: {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.0.dev18
+current_version = 2.13.0.dev13
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
@@ -19,6 +19,6 @@ values =
 search = {{%- set version = "{current_version}" %}}
 replace = {%- set version = "{new_version}" %}
 
-[bumpversion:file:recipe/meta.yaml]
+
 search = {{%- set git_rev = "v{current_version}" %}}
 replace = {%- set git_rev = "v{new_version}" %}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.0.dev16
+current_version = 2.13.0.dev17
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,15 +1,15 @@
 [bumpversion]
-current_version = 2.13.0.dev16
+current_version = 2.13.0.dev15
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	dev
 	gamma
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.0.dev19
+current_version = 2.13.0.dev20
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.1.dev0
+current_version = 2.13.1.dev1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,7 +16,9 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search = version = "{current_version}"
-replace = version = "{new_version}"
-search = git_rev = "v{current_version}"
-replace = git_rev = "v{new_version}"
+search =
+    version = "{current_version}"
+    git_rev = "v{current_version}"
+replace =
+    version = "{new_version}"
+    git_rev = "v{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,15 +1,15 @@
 [bumpversion]
-current_version = 2.13.0.dev15
+current_version = 2.13.0.dev16
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values =
+values = 
 	dev
 	gamma
 
@@ -18,4 +18,3 @@ values =
 [bumpversion:file:recipe/meta.yaml]
 search = version = "{current_version}"
 replace = version = "{current_version}"
-

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,17 +1,17 @@
 [bumpversion]
-current_version = 2.13.0.dev13
+current_version = 2.13.0.dev14
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize =
-    {major}.{minor}.{patch}.{release}{dev}
-    {major}.{minor}.{patch}
+serialize = 
+	{major}.{minor}.{patch}.{release}{dev}
+	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values =
-    dev
-    gamma
+values = 
+	dev
+	gamma
 
 [bumpversion:part:dev]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.13.0.dev14
+current_version = 2.13.0.dev15
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -18,8 +18,5 @@ values =
 [bumpversion:file:recipe/meta.yaml]
 search = version = "{current_version}"
 replace = version = "{new_version}"
-
-
-[bumpversion:file:recipe/meta.yaml]
 search = git_rev = "v{current_version}"
 replace = git_rev = "v{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,15 +1,15 @@
 [bumpversion]
-current_version = 2.13.0.dev13
+current_version = 2.13.0.dev14
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values =
+values = 
 	dev
 	gamma
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,17 +1,17 @@
 [bumpversion]
-current_version = 2.13.0.dev13
+current_version = 2.13.1.dev0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize =
-    {major}.{minor}.{patch}.{release}{dev}
-    {major}.{minor}.{patch}
+serialize = 
+	{major}.{minor}.{patch}.{release}{dev}
+	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values =
-    dev
-    gamma
+values = 
+	dev
+	gamma
 
 [bumpversion:part:dev]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,5 +16,5 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search = {{%- set version = "{current_version}" %}}
-replace = {%- set version = "{new_version}" %}
+search = {%- set version = "{current_version}" %}.*{%- set git_rev = "v{current_version}" %}
+replace = {%- set version = "{new_version}" %} {%- set git_rev = "v{new_version}" %}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,15 +1,15 @@
 [bumpversion]
-current_version = 2.13.0.dev14
+current_version = 2.13.0.dev13
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	dev
 	gamma
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,9 +16,6 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search =
-    version = "{current_version}"
-    git_rev = "v{current_version}"
-replace =
-    version = "{new_version}"
-    git_rev = "v{new_version}"
+search = version = "{current_version}"
+replace = version = "{current_version}"
+

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -17,8 +17,8 @@ values =
 
 [bumpversion:file:recipe/meta.yaml]
 search =
-    version = "{current_version}"
-    git_rev = "v{current_version}"
+    {% set version = "{current_version}" %}
+    {% set git_rev = "v{current_version}" %}
 replace =
-    version = "{new_version}"
-    git_rev = "v{new_version}"
+    {% set version = "{new_version}" %}
+    {% set git_rev = "v{new_version}" %}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,18 +3,22 @@ current_version = 2.13.1.dev2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	dev
 	gamma
 
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search = version = "{current_version}"
-replace = version = "{new_version}"
+search =
+    version = "{current_version}"
+    git_rev = "v{current_version}"
+replace =
+    version = "{new_version}"
+    git_rev = "v{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,21 +4,21 @@ commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize =
-	{major}.{minor}.{patch}.{release}{dev}
-	{major}.{minor}.{patch}
+    {major}.{minor}.{patch}.{release}{dev}
+    {major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
 values =
-	dev
-	gamma
+    dev
+    gamma
 
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
 search =
-    {% set version = "{current_version}" %}
-    {% set git_rev = "v{current_version}" %}
+    \{\% set version = "{current_version}" \%\}
+    \{\% set git_rev = "v{current_version}" \%\}
 replace =
-    {% set version = "{new_version}" %}
-    {% set git_rev = "v{new_version}" %}
+    \{\% set version = "{new_version}" \%\}
+    \{\% set git_rev = "v{new_version}" \%\}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,9 +16,5 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:recipe/meta.yaml]
-search =
-    version = "{current_version}"
-    git_rev = "v{current_version}"
-replace =
-    version = "{new_version}"
-    git_rev = "v{new_version}"
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -17,8 +17,8 @@ values =
 
 [bumpversion:file:recipe/meta.yaml]
 search =
-    \{\% set version = "{current_version}" \%\}
-    \{\% set git_rev = "v{current_version}" \%\}
+    {{% set version = "{current_version}" %}}
+    {{% set git_rev = "v{current_version}" %}}
 replace =
-    \{\% set version = "{new_version}" \%\}
-    \{\% set git_rev = "v{new_version}" \%\}
+    {{% set version = "{new_version}" %}}
+    {{% set git_rev = "v{new_version}" %}}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,24 @@
+[bumpversion]
+current_version = 2.13.0.dev18
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
+serialize =
+    {major}.{minor}.{patch}.{release}{dev}
+    {major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = gamma
+values =
+    dev
+    gamma
+
+[bumpversion:part:dev]
+
+[bumpversion:file:recipe/meta.yaml]
+search = {{%- set version = "{current_version}" %}}
+replace = {%- set version = "{new_version}" %}
+
+[bumpversion:file:recipe/meta.yaml]
+search = {{%- set git_rev = "v{current_version}" %}}
+replace = {%- set git_rev = "v{new_version}" %}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -17,8 +17,8 @@ values =
 
 [bumpversion:file:recipe/meta.yaml]
 search =
-    {{% set version = "{current_version}" %}}
-    {{% set git_rev = "v{current_version}" %}}
+    {% set version = "{current_version}" %}
+    {% set git_rev = "v{current_version}" %}
 replace =
-    {{% set version = "{new_version}" %}}
-    {{% set git_rev = "v{new_version}" %}}
+    {% set version = "{new_version}" %}
+    {% set git_rev = "v{new_version}" %}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 *.pyc
 
 !.github/workflows/bump_version_on_dispatch.yml
+!.bumpversion.cfg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev14" %}
+  {% set version = "2.13.0.dev13" %}
   {% set build = "0" %}
   {% set git_rev = "v2.13.0.dev13" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "version = "2.13.0.dev15"" %}
+  {% set version = "2.13.0.dev15" %}
   {% set build = "0" %}
   {% set git_rev = "v" + version %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "tudat" %}
   {% set version = "2.13.0.dev13" %}
   {% set build = "0" %}
-  {% set git_rev = "v2.13.0.dev13" %}
+  {% set git_rev = "v2.13.0.dev14" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,12 +4,12 @@
   {% set git_rev = "v2.13.0.dev13" %}
 
 package:
-  name: {{ name }}
-  version: {{ version }}
+  name: tudat
+  version: "2.13.0.dev13"
 
 source:
   git_url: https://github.com/tudat-team/tudat.git
-  git_rev: {{ git_rev }}
+  git_rev: "v2.13.0.dev13"
 
 build:
     # A non-negative integer representing the build number of the package.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "tudat" %}
   {% set version = "2.13.0.dev15" %}
   {% set build = "0" %}
-  {% set git_rev = "v2.13.0.dev15" %}
+  {% set git_rev = "v" + version %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev16" %}
+  {% set version = "2.13.0.dev17" %}
   {% set build = "0" %}
   {% set git_rev = "v" + version %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev20" %}
+  {% set version = "2.13.0.dev21" %}
   {% set build = "0" %}
   {% set git_rev = "v" + version %} # git_rev must point to the version tag. Hardcoded version can be replaced by assigning it using the version variable.This also solves formatting and indenantion issues while using the bumpversion command.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev13" %}
+  {% set version = "2.13.0.dev15" %}
   {% set build = "0" %}
   {% set git_rev = "v2.13.0.dev15" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
 {% set name = "tudat" %}
   {% set version = "2.13.0.dev20" %}
   {% set build = "0" %}
-  {% set git_rev = "v" + version %}
+  {% set git_rev = "v" + version %} # git_rev must point to the version tag. Hardcoded version can be replaced by assigning it using the version variable.This also solves formatting and indenantion issues while using the bumpversion command.
+
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "tudat" %}
   {% set version = "2.13.0.dev13" %}
   {% set build = "0" %}
-  {% set git_rev = "v2.13.0.dev14" %}
+  {% set git_rev = "v2.13.0.dev15" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: tudat
-  version: "2.13.0.dev13"
+  version: 2.13.0.dev13
 
 source:
   git_url: https://github.com/tudat-team/tudat.git
-  git_rev: "v2.13.0.dev13"
+  git_rev: v2.13.0.dev13
 
 build:
     # A non-negative integer representing the build number of the package.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev19" %}
+  {% set version = "2.13.0.dev20" %}
   {% set build = "0" %}
   {% set git_rev = "v" + version %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,3 @@
-{% set name = "tudat" %}
-  {% set version = "2.13.0.dev13" %}
-  {% set build = "0" %}
-  {% set git_rev = "v2.13.0.dev13" %}
-
 package:
   name: tudat
   version: "2.13.0.dev13"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev18" %}
+  {% set version = "2.13.0.dev19" %}
   {% set build = "0" %}
   {% set git_rev = "v" + version %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.1.dev0" %}
+  {% set version = "2.13.1.dev1" %}
   {% set build = "0" %}
   {% set git_rev = "v2.13.0.dev13" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "tudat" %}
   {% set version = "2.13.0.dev13" %}
   {% set build = "0" %}
-  {% set git_rev = "v2.13.0.dev14" %}
+  {% set git_rev = "v2.13.0.dev13" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev13" %}
+  {% set version = "2.13.0.dev14" %}
   {% set build = "0" %}
   {% set git_rev = "v2.13.0.dev13" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.1.dev1" %}
+  {% set version = "2.13.1.dev2" %}
   {% set build = "0" %}
   {% set git_rev = "v2.13.0.dev13" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev15" %}
+  {% set version = "2.13.0.dev16" %}
   {% set build = "0" %}
   {% set git_rev = "v" + version %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,15 @@
+{% set name = "tudat" %}
+  {% set version = "2.13.0.dev13" %}
+  {% set build = "0" %}
+  {% set git_rev = "v2.13.0.dev13" %}
+
 package:
-  name: tudat
-  version: 2.13.0.dev13
+  name: {{ name }}
+  version: {{ version }}
 
 source:
   git_url: https://github.com/tudat-team/tudat.git
-  git_rev: v2.13.0.dev13
+  git_rev: {{ git_rev }}
 
 build:
     # A non-negative integer representing the build number of the package.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.1.dev2" %}
+  {% set version = "2.13.0.dev13" %}
   {% set build = "0" %}
   {% set git_rev = "v2.13.0.dev13" %}
 
@@ -25,7 +25,7 @@ requirements:
     # Tools required to build the package. These packages are run on the build
     # system and include things such as revision control systems (Git, SVN) make
     # tools (GNU make, Autotool, CMake) and compilers (real cross, pseudo-cross,
-    # or native when not cross-compiling), and any source pre-processors.   
+    # or native when not cross-compiling), and any source pre-processors.
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
     - cmake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev13" %}
+  {% set version = "2.13.1.dev0" %}
   {% set build = "0" %}
   {% set git_rev = "v2.13.0.dev13" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev17" %}
+  {% set version = "2.13.0.dev18" %}
   {% set build = "0" %}
   {% set git_rev = "v" + version %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tudat" %}
-  {% set version = "2.13.0.dev15" %}
+  {% set version = "version = "2.13.0.dev15"" %}
   {% set build = "0" %}
   {% set git_rev = "v" + version %}
 


### PR DESCRIPTION
### Summary of code changes
- Modify the .bumpversion.cfg and meta.yml to make the bumpversion command bump the version number in meta.yml
- assign git_rev using version to reduce room for errors. git_rev had been hardcoded with the same version number as in the variable 'version'. 